### PR TITLE
Added Error Handling for Bad iri server

### DIFF
--- a/command/deltangle.js
+++ b/command/deltangle.js
@@ -69,7 +69,7 @@ if (arg.save) {
 	console.log('  --channelLayers layers\n      Channel layers used for versions. Default: ' + defaultChannelLayers)
 	console.log('  --channelDepth depth\n      Channel depth used for versions. Default: ' + defaultChannelDepth)
 	console.log('\nand <command> is one of:')
-	console.log('  --save <file> [--hash hash]\n      Save a file. Add --hash with a given hash to save difference with the previous one')
+	console.log('  --save <file or text> [--hash hash]\n      Save a file or a string of text. Add --hash with a given hash to save difference with the previous one')
 	console.log('  --obtain hash\n      Get a file')
 	console.log('  --version hash [--seed seed]\n      Create or update a version. Add --seed to update a version or create a new version using this seed')
 }

--- a/command/deltangle.js
+++ b/command/deltangle.js
@@ -24,7 +24,10 @@ function getInstance() {
 }
 
 async function save() {
-	let content = await fs.readFileSync(arg.save, 'ascii')
+        let content = arg.save
+        if (fs.existsSync(arg.save)){
+        	let content = await fs.readFileSync(arg.save, 'ascii')
+        }
 	let instance = getInstance()
 	let hash = undefined
 	if (arg.hash) {

--- a/dist/deltangle.js
+++ b/dist/deltangle.js
@@ -16,7 +16,7 @@ class Deltangle {
 		return content
 	}
 
-        async post(content, previous = null) {
+	async post(content, previous = null) {
 	        this.iota.api.getNodeInfo((err,sucess) => {
 			if(err) {
 				console.log("\nApi not working; Connect to a diffierent host using the flag --provider.")

--- a/dist/deltangle.js
+++ b/dist/deltangle.js
@@ -16,7 +16,8 @@ class Deltangle {
 		return content
 	}
 
-	async post(content, previous = null) {
+        async post(content, previous = null) {
+	        this.iota.api.getNodeInfo((err,sucess) => { if(err) throw("\nApi not working; Connect to a diffierent host.") })
 		if (previous != null) {
 			let previousContent = await this.get(previous)
 			content = JsDiff.createPatch('', previousContent, content, '', '', { context: 1 })

--- a/dist/deltangle.js
+++ b/dist/deltangle.js
@@ -17,7 +17,12 @@ class Deltangle {
 	}
 
         async post(content, previous = null) {
-	        this.iota.api.getNodeInfo((err,sucess) => { if(err) throw("\nApi not working; Connect to a diffierent host.") })
+	        this.iota.api.getNodeInfo((err,sucess) => {
+			if(err) {
+				console.log("\nApi not working; Connect to a diffierent host.")
+				process.exit()
+			}
+		})
 		if (previous != null) {
 			let previousContent = await this.get(previous)
 			content = JsDiff.createPatch('', previousContent, content, '', '', { context: 1 })

--- a/dist/deltangle.js
+++ b/dist/deltangle.js
@@ -19,7 +19,7 @@ class Deltangle {
         async post(content, previous = null) {
 	        this.iota.api.getNodeInfo((err,sucess) => {
 			if(err) {
-				console.log("\nApi not working; Connect to a diffierent host.")
+				console.log("\nApi not working; Connect to a diffierent host using the flag --provider.")
 				process.exit()
 			}
 		})


### PR DESCRIPTION
It used to display 

    (node:8667) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '0' of undefined
        at Deltangle.post (/home/wil/Documents/deltangle/lib/deltangle.js:35:16)
        at process._tickCallback (internal/process/next_tick.js:68:7)
But now it says 

    Api not working; Connect to a diffierent host.